### PR TITLE
Changed the log folder naming to use safe characters for Windows and Linux

### DIFF
--- a/run.py
+++ b/run.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         log_dir = os.path.join(*os.path.split(opt.checkpoint)[:-1])
     else:
         log_dir = os.path.join(opt.log_dir, os.path.basename(opt.config).split('.')[0])
-        log_dir += ' ' + strftime("%d-%m-%y %H:%M:%S", gmtime())
+        log_dir += ' ' + strftime("%d_%m_%y_%H.%M.%S", gmtime())
 
     generator = OcclusionAwareGenerator(**config['model_params']['generator_params'],
                                         **config['model_params']['common_params'])


### PR DESCRIPTION
I replaced some special characters like `:` in the time for `.` to avoid errors on Windows as a folder can not contain on windows those characters on their name.