### PR TITLE
Fixed PyYAML yaml.load() Deprecation warning (again).

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -22,7 +22,7 @@ from scipy.spatial import ConvexHull
 def load_checkpoints(config_path, checkpoint_path):
 
     with open(config_path) as f:
-        config = yaml.load(f)
+        config = yaml.load(f, Loader=yaml.FullLoader)
 
     generator = OcclusionAwareGenerator(**config['model_params']['generator_params'],
                                         **config['model_params']['common_params'])
@@ -132,5 +132,5 @@ if __name__ == "__main__":
         predictions = predictions_backward[::-1] + predictions_forward[1:]
     else:
         predictions = make_animation(source_image, driving_video, generator, kp_detector, relative=opt.relative, adapt_movement_scale=opt.adapt_scale)
-    imageio.mimsave(opt.result_video, predictions, fps=fps)
+    imageio.mimsave(opt.result_video, [img_as_ubyte(frame) for frame in predictions], fps=fps)
 


### PR DESCRIPTION
Im doing this changes again to fix once more the `PyYAML yaml.load(input)` deprecation warning and also the `Lossy conversion from float32 to uint8` warning. I already had created a PR for this changes before and it was merged but for some reason the code was not merged correctly and nothing really changed on the main repository, I hope this time it does work.