### PR TITLE
Added a missing import on the demo file

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 import imageio
 import numpy as np
 from skimage.transform import resize
+from skimage import img_as_ubyte
 
 import torch
 from sync_batchnorm import DataParallelWithCallback


### PR DESCRIPTION
I forgot to import `img_as_ubyte` from `skimage`, this caused a NameError as seen on Issue #62