### PR TITLE
fixing bug with getting frames of video

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -131,8 +131,13 @@ if __name__ == "__main__":
     source_image = imageio.imread(opt.source_image)
     reader = imageio.get_reader(opt.driving_video)
     fps = reader.get_meta_data()['fps']
+    driving_video = []
+    try:
+        for im in reader:
+            driving_video.append(im)
+    except RuntimeError:
+        pass
     reader.close()
-    driving_video = imageio.mimread(opt.driving_video, memtest=False)
 
     source_image = resize(source_image, (256, 256))[..., :3]
     driving_video = [resize(frame, (256, 256))[..., :3] for frame in driving_video]


### PR DESCRIPTION
This fixes a bug I ran into on Ubuntu 18.04 with the default ffmpeg, and updated to 4.2, and I traced it down to imageio not correctly reading the number of frames (and throwing an error when it got to the last section and reporting 0). This comes down to changing:

```python
driving_video = imageio.mimread(opt.driving_video, memtest=False)
```

to

```python
driving_video = []
try:
    for im in reader:
        driving_video.append(im)
except RuntimeError:
    pass
```

I also:

 - added likely folders to the .gitignore
 - ensured we use the yaml.FullLoader for safe yaml loading

And I just want to say I'm absolutely in love with this work! I generated several videos using paintings over night, and am going to build a Docker -> Singularity container today to run on our cluster with GPU (and try out some of the other models!) Thank you so kindly for this work (and the spot on documentation for reproducing it!)

Signed-off-by: vsoch <vsochat@stanford.edu>