### PR TITLE
Fix crop-video scale argument

### DIFF
--- a/crop-video.py
+++ b/crop-video.py
@@ -46,7 +46,7 @@ def join(tube_bbox, bbox):
     return (xA, yA, xB, yB)
 
 
-def compute_bbox(start, end, fps, tube_bbox, frame_shape, inp, increase_area=0.1):
+def compute_bbox(start, end, fps, tube_bbox, frame_shape, inp, image_shape, increase_area=0.1):
     left, top, right, bot = tube_bbox
     width = right - left
     height = bot - top
@@ -67,14 +67,16 @@ def compute_bbox(start, end, fps, tube_bbox, frame_shape, inp, increase_area=0.1
     end = end / fps
     time = end - start
 
-    return f'ffmpeg -i {inp} -ss {start} -t {time} -filter:v "crop={w}:{h}:{left}:{top}, scale=256:256" crop.mp4'
+    scale = f'{image_shape[0]}:{image_shape[1]}'
+
+    return f'ffmpeg -i {inp} -ss {start} -t {time} -filter:v "crop={w}:{h}:{left}:{top}, scale={scale}" crop.mp4'
 
 
 def compute_bbox_trajectories(trajectories, fps, frame_shape, args):
     commands = []
     for i, (bbox, tube_bbox, start, end) in enumerate(trajectories):
         if (end - start) > args.min_frames:
-            command = compute_bbox(start, end, fps, tube_bbox, frame_shape, inp=args.inp, increase_area=args.increase)
+            command = compute_bbox(start, end, fps, tube_bbox, frame_shape, inp=args.inp, image_shape=args.image_shape, increase_area=args.increase)
             commands.append(command)
     return commands
 
@@ -153,3 +155,4 @@ if __name__ == "__main__":
     for command in commands:
         print (command)
 
+        


### PR DESCRIPTION
Passing argument `--image_shape` was not changing anything, because scale in ffmpeg command was hard coded to 256:256