### PR TITLE
Fixed non-existing Torch version for pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ scikit-learn==0.19.2
 scipy==1.1.0
 six==1.11.0
 toolz==0.9.0
-torch==1.0.0
+torch==1.7.1
 torchvision==0.2.1
 tqdm==4.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ scikit-image==0.14.0
 scikit-learn==0.19.2
 scipy==1.1.0
 six==1.11.0
-toolz==0.9.0
-torch==1.7.1
-torchvision==0.2.1
+toolz==0.11.1
+torch===1.7.1+cu110
+torchvision===0.8.2+cu110
 tqdm==4.24.0


### PR DESCRIPTION
Other potential version changes that might be worth using:

- Pillow 6.2.1 could be added, at least on another project that is based on this repository it is required for compiling with PyInstaller (optional).