### PR TITLE
feat: adds audio_on option (#434)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -17,6 +17,8 @@ from modules.keypoint_detector import KPDetector
 from animate import normalize_kp
 from scipy.spatial import ConvexHull
 
+import moviepy
+import moviepy.editor as mpe
 
 if sys.version_info[0] < 3:
     raise Exception("You must use Python 3 or higher. Recommended version is Python 3.7")
@@ -121,10 +123,12 @@ if __name__ == "__main__":
                         help="Set frame to start from.")
  
     parser.add_argument("--cpu", dest="cpu", action="store_true", help="cpu mode.")
- 
+    
+    parser.add_argument("--audio_on", dest="audio_on", action="store_true", help="option to have audio on." )
 
     parser.set_defaults(relative=False)
     parser.set_defaults(adapt_scale=False)
+    parser.set_defaults(audio_on=False)
 
     opt = parser.parse_args()
 
@@ -154,4 +158,12 @@ if __name__ == "__main__":
     else:
         predictions = make_animation(source_image, driving_video, generator, kp_detector, relative=opt.relative, adapt_movement_scale=opt.adapt_scale, cpu=opt.cpu)
     imageio.mimsave(opt.result_video, [img_as_ubyte(frame) for frame in predictions], fps=fps)
+
+    if opt.audio_on:
+        video_clip = mpe.VideoFileClip(opt.result_video)
+        audio_clip = mpe.AudioFileClip(opt.driving_video)
+
+        final_clip = video_clip.set_audio(audio_clip)
+        file_name_with_audio = opt.result_video.split(".")[0] + "-with-audio.mp4"
+        final_clip.write_videofile(file_name_with_audio, fps=fps, codec='libx264', audio_codec='aac', write_logfile=True, ffmpeg_params=['-level','4.0','-b:a','128k'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
-imageio==2.3.0
+imageio==2.13.3
 matplotlib==2.2.2
-numpy==1.15.0
+numpy==1.19.5
 pandas==0.23.4
 python-dateutil==2.7.3
 pytz==2018.5
 PyYAML==5.1
-scikit-image==0.14.0
+scikit-image==0.14.2
 scikit-learn==0.19.2
 scipy==1.1.0
 torch==1.0.0
 torchvision==0.2.1
 tqdm==4.24.0
+moviepy==1.0.3


### PR DESCRIPTION
Resolves #434 
1. adds audio_on argument on demo.py
2. if user adds --audio_on as argument, it will generate another mp4 file with name: <result_vid_name>-with-audio.mp4
3. adds moviepy library and updates versions of numpy, imageio, scikit-image